### PR TITLE
fix: provide tenant id for message service call

### DIFF
--- a/src/main/java/de/caritas/cob/videoservice/api/service/RejectVideoCallService.java
+++ b/src/main/java/de/caritas/cob/videoservice/api/service/RejectVideoCallService.java
@@ -19,6 +19,7 @@ public class RejectVideoCallService {
 
   private final @NonNull MessageControllerApi messageControllerApi;
   private final @NonNull SecurityHeaderSupplier securityHeaderSupplier;
+  private final @NonNull TenantHeaderSupplier tenantHeaderSupplier;
 
   /**
    * Sends a system message with rejection type to the message service.
@@ -34,6 +35,7 @@ public class RejectVideoCallService {
 
   private void addDefaultHeaders(ApiClient apiClient) {
     var headers = this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders();
+    tenantHeaderSupplier.addTenantHeader(headers);
     headers.forEach((key, value) -> apiClient.addDefaultHeader(key, value.iterator().next()));
   }
 

--- a/src/main/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplier.java
+++ b/src/main/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplier.java
@@ -2,7 +2,6 @@ package de.caritas.cob.videoservice.api.service;
 
 import de.caritas.cob.videoservice.api.tenant.TenantContext;
 import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,12 +32,11 @@ public class TenantHeaderSupplier {
   /**
    * Resolve tenantID from current request.
    *
-   * @return
+   * @return the id of the tenant
    */
   public Optional<Long> getTenantFromHeader() {
-    HttpServletRequest request =
-        ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-            .getRequest();
+    var request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+        .getRequest();
     try {
       return Optional.of(Long.parseLong(request.getHeader("tenantId")));
     } catch (NumberFormatException exception) {
@@ -46,4 +44,5 @@ public class TenantHeaderSupplier {
       return Optional.empty();
     }
   }
+
 }

--- a/src/test/java/de/caritas/cob/videoservice/api/service/RejectVideoCallServiceTest.java
+++ b/src/test/java/de/caritas/cob/videoservice/api/service/RejectVideoCallServiceTest.java
@@ -1,7 +1,6 @@
 package de.caritas.cob.videoservice.api.service;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +31,9 @@ public class RejectVideoCallServiceTest {
   private SecurityHeaderSupplier securityHeaderSupplier;
 
   @Mock
+  private TenantHeaderSupplier tenantHeaderSupplier;
+
+  @Mock
   private ApiClient apiClient;
 
   @Test
@@ -46,9 +48,10 @@ public class RejectVideoCallServiceTest {
         .eventType(EventTypeEnum.IGNORED_CALL)
         .initiatorUserName(rejectVideoCallDto.getInitiatorUsername())
         .initiatorRcUserId(rejectVideoCallDto.getInitiatorRcUserId());
-    verify(this.securityHeaderSupplier, times(1)).getKeycloakAndCsrfHttpHeaders();
-    verify(this.messageControllerApi, times(1))
-        .createVideoHintMessage(eq(rejectVideoCallDto.getRcGroupId()), eq(expectedMessage));
+    verify(this.securityHeaderSupplier).getKeycloakAndCsrfHttpHeaders();
+    verify(this.tenantHeaderSupplier).addTenantHeader(any());
+    verify(this.messageControllerApi)
+        .createVideoHintMessage(rejectVideoCallDto.getRcGroupId(), expectedMessage);
   }
 
 }

--- a/src/test/java/de/caritas/cob/videoservice/api/service/RejectVideoCallServiceTest.java
+++ b/src/test/java/de/caritas/cob/videoservice/api/service/RejectVideoCallServiceTest.java
@@ -38,9 +38,10 @@ public class RejectVideoCallServiceTest {
 
   @Test
   public void rejectVideoCall_Should_useServicesCorrectly() {
+    var securityHeaders = new HttpHeaders();
     when(this.messageControllerApi.getApiClient()).thenReturn(this.apiClient);
-    when(this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(new HttpHeaders());
-    RejectVideoCallDTO rejectVideoCallDto = new EasyRandom().nextObject(RejectVideoCallDTO.class);
+    when(this.securityHeaderSupplier.getKeycloakAndCsrfHttpHeaders()).thenReturn(securityHeaders);
+    var rejectVideoCallDto = new EasyRandom().nextObject(RejectVideoCallDTO.class);
 
     this.rejectVideoCallService.rejectVideoCall(rejectVideoCallDto);
 
@@ -49,7 +50,7 @@ public class RejectVideoCallServiceTest {
         .initiatorUserName(rejectVideoCallDto.getInitiatorUsername())
         .initiatorRcUserId(rejectVideoCallDto.getInitiatorRcUserId());
     verify(this.securityHeaderSupplier).getKeycloakAndCsrfHttpHeaders();
-    verify(this.tenantHeaderSupplier).addTenantHeader(any());
+    verify(this.tenantHeaderSupplier).addTenantHeader(securityHeaders);
     verify(this.messageControllerApi)
         .createVideoHintMessage(rejectVideoCallDto.getRcGroupId(), expectedMessage);
   }

--- a/src/test/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplierSupplierTest.java
+++ b/src/test/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplierSupplierTest.java
@@ -1,0 +1,69 @@
+package de.caritas.cob.videoservice.api.service;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import de.caritas.cob.videoservice.api.tenant.TenantContext;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class TenantHeaderSupplierSupplierTest {
+
+  private final TenantHeaderSupplier tenantHeaderSupplier = new TenantHeaderSupplier();
+
+  @Test
+  void addTenantHeader_Should_addTenantIdToHeaders_When_multiTenancyIsEnabled() {
+    setField(tenantHeaderSupplier, "multitenancy", true);
+    var httpHeaders = new HttpHeaders();
+    TenantContext.setCurrentTenant(1L);
+
+    tenantHeaderSupplier.addTenantHeader(httpHeaders);
+
+    assertThat(httpHeaders.get("tenantId").get(0), is("1"));
+  }
+
+  @Test
+  void addTenantHeader_Should_notAddTenantIdToHeaders_When_multiTenancyIsDisabled() {
+    setField(tenantHeaderSupplier, "multitenancy", false);
+    var httpHeaders = new HttpHeaders();
+
+    tenantHeaderSupplier.addTenantHeader(httpHeaders);
+
+    assertThat(httpHeaders.get("tenantId"), nullValue());
+  }
+
+  @Test
+  void getTenantFromHeader_Should_returnTenantId_When_tenantIdExistsInHeader() {
+    givenMockedServletRequestWithTenandIdHeaderValue("1");
+
+    var result = tenantHeaderSupplier.getTenantFromHeader();
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get(), is(1L));
+  }
+
+  @Test
+  void getTenantFromHeader_Should_returnOptionalEmpty_When_tenantIdIsNoNumber() {
+    givenMockedServletRequestWithTenandIdHeaderValue("no number");
+
+    var result = tenantHeaderSupplier.getTenantFromHeader();
+
+    assertThat(result.isPresent(), is(false));
+  }
+
+  private void givenMockedServletRequestWithTenandIdHeaderValue(String tenantIdValue) {
+    var mockedServletRequest = mock(HttpServletRequest.class);
+    when(mockedServletRequest.getHeader("tenantId")).thenReturn(tenantIdValue);
+    var requestAttributes = new ServletRequestAttributes(mockedServletRequest);
+    RequestContextHolder.setRequestAttributes(requestAttributes);
+  }
+
+}

--- a/src/test/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplierTest.java
+++ b/src/test/java/de/caritas/cob/videoservice/api/service/TenantHeaderSupplierTest.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-class TenantHeaderSupplierSupplierTest {
+class TenantHeaderSupplierTest {
 
   private final TenantHeaderSupplier tenantHeaderSupplier = new TenantHeaderSupplier();
 


### PR DESCRIPTION
- added missing tests for tenant header supplier